### PR TITLE
get all packages functionality

### DIFF
--- a/backend/src/routes/packages.ts
+++ b/backend/src/routes/packages.ts
@@ -39,8 +39,14 @@ router.post('/packages', async (req, res) => {
     const offsetInt = parseInt(offset as string, 10);
     
     const pageSize = 10;
-    let query = 'SELECT * FROM packages WHERE package_name = ?';
-    let queryParams = [packageId];
+    let query = 'SELECT * FROM packages';
+    let queryParams: any[] = [];
+
+    // get packageId if specified
+    if (packageId){
+      query += ' WHERE package_name = ?';
+      queryParams = [packageId];
+    }
 
     // Handle version filtering if specified
     if (version) {

--- a/frontend/src/components/PackageVersion.tsx
+++ b/frontend/src/components/PackageVersion.tsx
@@ -10,11 +10,6 @@ const PackageVersion: React.FC = () => {
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
 
-    if (!packageName) {
-      alert('Please provide the package name!');
-      return;
-    }
-
     try {
       await fetchPackageVersion(packageName, version);
       alert('Package version fetched successfully!');


### PR DESCRIPTION
Packages assumed user always gave a name, specs say if name isn't specified then get everything.

Just changed a few lines to support that case.