### PR TITLE
Add metrics calculator script and sample files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "ros.distro": "humble"
+}

--- a/MetricsCalculator/run.py
+++ b/MetricsCalculator/run.py
@@ -1,0 +1,84 @@
+import json
+import sys
+import time
+
+# Metric Calculation Functions
+def calculate_ramp_up(package_data):
+    if "readme" in package_data or "description" in package_data or "main" in package_data:
+        return 0.7  # Example: well-documented
+    return 0.3  # Poorly documented
+
+def calculate_correctness(package_lock):
+    outdated = 0
+    total = len(package_lock.get("packages", {}))
+    for pkg in package_lock.get("packages", {}).values():
+        if pkg.get("dev"):  # Example check: consider dev dependencies
+            outdated += 1
+    return 1 - (outdated / total if total else 0)
+
+def calculate_bus_factor(package_data):
+    return 0.5 if "author" in package_data else 0.2
+
+def calculate_responsive_maintainer(package_lock):
+    recent_updates = [pkg for pkg in package_lock.get("packages", {}).values() if "time" in pkg]
+    return 0.8 if recent_updates else 0.2
+
+def calculate_license(package_data):
+    license_type = package_data.get("license", "").lower()
+    if license_type in ["mit", "apache-2.0", "lgpl-2.1-only"]:
+        return 1.0
+    return 0.0
+
+# Handle Missing Metrics
+def handle_missing_metrics(metric_function, *args):
+    try:
+        return metric_function(*args)
+    except Exception:
+        return -1
+
+# Calculate Metrics and Latencies
+def calculate_metrics(package_data, package_lock):
+    metrics = {}
+    start = time.time()
+    metrics["RampUp"] = handle_missing_metrics(calculate_ramp_up, package_data)
+    metrics["RampUp_Latency"] = round(time.time() - start, 3)
+
+    start = time.time()
+    metrics["Correctness"] = handle_missing_metrics(calculate_correctness, package_lock)
+    metrics["Correctness_Latency"] = round(time.time() - start, 3)
+
+    start = time.time()
+    metrics["BusFactor"] = handle_missing_metrics(calculate_bus_factor, package_data)
+    metrics["BusFactor_Latency"] = round(time.time() - start, 3)
+
+    start = time.time()
+    metrics["ResponsiveMaintainer"] = handle_missing_metrics(calculate_responsive_maintainer, package_lock)
+    metrics["ResponsiveMaintainer_Latency"] = round(time.time() - start, 3)
+
+    start = time.time()
+    metrics["License"] = handle_missing_metrics(calculate_license, package_data)
+    metrics["License_Latency"] = round(time.time() - start, 3)
+
+    # Example NetScore calculation
+    metrics["NetScore"] = sum([metrics["RampUp"], metrics["Correctness"], metrics["BusFactor"],
+                               metrics["ResponsiveMaintainer"], metrics["License"]]) / 5
+    metrics["NetScore_Latency"] = round(time.time() - start, 3)
+
+    return metrics
+
+# Read Input Files
+def read_files(package_path, package_lock_path):
+    with open(package_path, "r") as pkg_file, open(package_lock_path, "r") as lock_file:
+        package_data = json.load(pkg_file)
+        package_lock = json.load(lock_file)
+    return package_data, package_lock
+
+# Main Function
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: ./run.py <path_to_package.json> <path_to_package-lock.json>")
+        sys.exit(1)
+
+    package_data, package_lock = read_files(sys.argv[1], sys.argv[2])
+    result = calculate_metrics(package_data, package_lock)
+    print(json.dumps(result, indent=2))

--- a/MetricsCalculator/sample_package-lock.json
+++ b/MetricsCalculator/sample_package-lock.json
@@ -1,0 +1,21 @@
+{
+    "name": "461-acme-service",
+    "version": "1.0.0",
+    "lockfileVersion": 2,
+    "packages": {
+      "": {
+        "name": "461-acme-service",
+        "version": "1.0.0",
+        "license": "MIT"
+      },
+      "node_modules/acorn": {
+        "version": "8.12.1",
+        "license": "MIT"
+      },
+      "node_modules/axios": {
+        "version": "1.7.7",
+        "license": "MIT"
+      }
+    }
+  }
+  

--- a/MetricsCalculator/sample_package.json
+++ b/MetricsCalculator/sample_package.json
@@ -1,0 +1,21 @@
+{
+    "name": "461-acme-service",
+    "version": "1.0.0",
+    "description": "Sample project",
+    "main": "index.js",
+    "scripts": {
+      "test": "jest",
+      "build": "npx tsc"
+    },
+    "keywords": [],
+    "author": "John Doe",
+    "license": "MIT",
+    "devDependencies": {
+      "@types/jest": "^29.5.13",
+      "@types/node": "^22.5.2",
+      "acorn": "^8.12.1",
+      "axios": "^1.7.7",
+      "typescript": "^5.5.4"
+    }
+  }
+  

--- a/run.py
+++ b/run.py
@@ -1,0 +1,84 @@
+import json
+import sys
+import time
+
+# Metric Calculation Functions
+def calculate_ramp_up(package_data):
+    if "readme" in package_data or "description" in package_data or "main" in package_data:
+        return 0.7  # Example: well-documented
+    return 0.3  # Poorly documented
+
+def calculate_correctness(package_lock):
+    outdated = 0
+    total = len(package_lock.get("packages", {}))
+    for pkg in package_lock.get("packages", {}).values():
+        if pkg.get("dev"):  # Example check: consider dev dependencies
+            outdated += 1
+    return 1 - (outdated / total if total else 0)
+
+def calculate_bus_factor(package_data):
+    return 0.5 if "author" in package_data else 0.2
+
+def calculate_responsive_maintainer(package_lock):
+    recent_updates = [pkg for pkg in package_lock.get("packages", {}).values() if "time" in pkg]
+    return 0.8 if recent_updates else 0.2
+
+def calculate_license(package_data):
+    license_type = package_data.get("license", "").lower()
+    if license_type in ["mit", "apache-2.0", "lgpl-2.1-only"]:
+        return 1.0
+    return 0.0
+
+# Handle Missing Metrics
+def handle_missing_metrics(metric_function, *args):
+    try:
+        return metric_function(*args)
+    except Exception:
+        return -1
+
+# Calculate Metrics and Latencies
+def calculate_metrics(package_data, package_lock):
+    metrics = {}
+    start = time.time()
+    metrics["RampUp"] = handle_missing_metrics(calculate_ramp_up, package_data)
+    metrics["RampUp_Latency"] = round(time.time() - start, 3)
+
+    start = time.time()
+    metrics["Correctness"] = handle_missing_metrics(calculate_correctness, package_lock)
+    metrics["Correctness_Latency"] = round(time.time() - start, 3)
+
+    start = time.time()
+    metrics["BusFactor"] = handle_missing_metrics(calculate_bus_factor, package_data)
+    metrics["BusFactor_Latency"] = round(time.time() - start, 3)
+
+    start = time.time()
+    metrics["ResponsiveMaintainer"] = handle_missing_metrics(calculate_responsive_maintainer, package_lock)
+    metrics["ResponsiveMaintainer_Latency"] = round(time.time() - start, 3)
+
+    start = time.time()
+    metrics["License"] = handle_missing_metrics(calculate_license, package_data)
+    metrics["License_Latency"] = round(time.time() - start, 3)
+
+    # Example NetScore calculation
+    metrics["NetScore"] = sum([metrics["RampUp"], metrics["Correctness"], metrics["BusFactor"],
+                               metrics["ResponsiveMaintainer"], metrics["License"]]) / 5
+    metrics["NetScore_Latency"] = round(time.time() - start, 3)
+
+    return metrics
+
+# Read Input Files
+def read_files(package_path, package_lock_path):
+    with open(package_path, "r") as pkg_file, open(package_lock_path, "r") as lock_file:
+        package_data = json.load(pkg_file)
+        package_lock = json.load(lock_file)
+    return package_data, package_lock
+
+# Main Function
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: ./run.py <path_to_package.json> <path_to_package-lock.json>")
+        sys.exit(1)
+
+    package_data, package_lock = read_files(sys.argv[1], sys.argv[2])
+    result = calculate_metrics(package_data, package_lock)
+    print(json.dumps(result, indent=2))

--- a/sample_package-lock.json
+++ b/sample_package-lock.json
@@ -1,0 +1,21 @@
+{
+    "name": "461-acme-service",
+    "version": "1.0.0",
+    "lockfileVersion": 2,
+    "packages": {
+      "": {
+        "name": "461-acme-service",
+        "version": "1.0.0",
+        "license": "MIT"
+      },
+      "node_modules/acorn": {
+        "version": "8.12.1",
+        "license": "MIT"
+      },
+      "node_modules/axios": {
+        "version": "1.7.7",
+        "license": "MIT"
+      }
+    }
+  }
+  

--- a/sample_package.json
+++ b/sample_package.json
@@ -1,0 +1,21 @@
+{
+    "name": "461-acme-service",
+    "version": "1.0.0",
+    "description": "Sample project",
+    "main": "index.js",
+    "scripts": {
+      "test": "jest",
+      "build": "npx tsc"
+    },
+    "keywords": [],
+    "author": "John Doe",
+    "license": "MIT",
+    "devDependencies": {
+      "@types/jest": "^29.5.13",
+      "@types/node": "^22.5.2",
+      "acorn": "^8.12.1",
+      "axios": "^1.7.7",
+      "typescript": "^5.5.4"
+    }
+  }
+  


### PR DESCRIPTION

This pull request introduces a `run.py` script that calculates quality metrics for `package.json` and `package-lock.json`. The script evaluates the following metrics:
- RampUp
- Correctness
- BusFactor
- ResponsiveMaintainer
- License
- NetScore (calculated as an average of the above)

Additionally, it includes two sample files (`sample_package.json` and `sample_package-lock.json`) for testing purposes.

### Why
These metrics will help the team assess the quality and reliability of packages used in our projects. This aligns with our goal to improve project maintainability and dependency management.

How:
- Implemented the script in `run.py` to:
  - Parse `package.json` and `package-lock.json`.
  - Compute individual metrics based on specific criteria.
  - Output a JSON object with metrics and latencies.
- Included sample files for testing and demonstration.

 Testing:
1. Run the script with:
   ```bash
   python3 run.py sample_package.json sample_package-lock.json
