### PR TITLE
Add recommend endpoint

### DIFF
--- a/.vscode/app.py
+++ b/.vscode/app.py
@@ -1,0 +1,54 @@
+from flask import Flask, request, jsonify
+import openai
+
+# Initialize Flask app
+app = Flask(__name__)
+
+# Configure OpenAI API key
+openai.api_key = "your_openai_api_key"
+
+# Example function to get package popularity (e.g., npm data)
+def get_package_popularity(package_name):
+    # Use the npm registry API to fetch download stats
+    response = requests.get(f"https://api.npmjs.org/downloads/point/last-month/{package_name}")
+    if response.status_code == 200:
+        data = response.json()
+        return data.get("downloads", 0)
+    return 0
+
+# Recommend endpoint
+@app.route("/recommend", methods=["POST"])
+def recommend_packages():
+    # Get description from request
+    description = request.json.get("description", "")
+    if not description:
+        return jsonify({"error": "Description is required"}), 400
+
+    try:
+        # Call OpenAI API
+        prompt = f"Recommend 5 npm packages based on the following description:\n\n{description}"
+        response = openai.Completion.create(
+            engine="text-davinci-003",
+            prompt=prompt,
+            max_tokens=100,
+            temperature=0.7
+        )
+        suggestions = response.choices[0].text.strip().split("\n")
+        
+        # Clean and validate suggestions
+        packages = []
+        for suggestion in suggestions:
+            package_name = suggestion.strip()
+            popularity = get_package_popularity(package_name)
+            packages.append({"name": package_name, "popularity": popularity})
+        
+        # Sort by popularity and return the top 5
+        top_packages = sorted(packages, key=lambda x: x["popularity"], reverse=True)[:5]
+        return jsonify({"description": description, "recommendations": top_packages})
+
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+# Run the app
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "ros.distro": "humble"
+}

--- a/MetricsCalculator/run.py
+++ b/MetricsCalculator/run.py
@@ -1,0 +1,84 @@
+import json
+import sys
+import time
+
+# Metric Calculation Functions
+def calculate_ramp_up(package_data):
+    if "readme" in package_data or "description" in package_data or "main" in package_data:
+        return 0.7  # Example: well-documented
+    return 0.3  # Poorly documented
+
+def calculate_correctness(package_lock):
+    outdated = 0
+    total = len(package_lock.get("packages", {}))
+    for pkg in package_lock.get("packages", {}).values():
+        if pkg.get("dev"):  # Example check: consider dev dependencies
+            outdated += 1
+    return 1 - (outdated / total if total else 0)
+
+def calculate_bus_factor(package_data):
+    return 0.5 if "author" in package_data else 0.2
+
+def calculate_responsive_maintainer(package_lock):
+    recent_updates = [pkg for pkg in package_lock.get("packages", {}).values() if "time" in pkg]
+    return 0.8 if recent_updates else 0.2
+
+def calculate_license(package_data):
+    license_type = package_data.get("license", "").lower()
+    if license_type in ["mit", "apache-2.0", "lgpl-2.1-only"]:
+        return 1.0
+    return 0.0
+
+# Handle Missing Metrics
+def handle_missing_metrics(metric_function, *args):
+    try:
+        return metric_function(*args)
+    except Exception:
+        return -1
+
+# Calculate Metrics and Latencies
+def calculate_metrics(package_data, package_lock):
+    metrics = {}
+    start = time.time()
+    metrics["RampUp"] = handle_missing_metrics(calculate_ramp_up, package_data)
+    metrics["RampUp_Latency"] = round(time.time() - start, 3)
+
+    start = time.time()
+    metrics["Correctness"] = handle_missing_metrics(calculate_correctness, package_lock)
+    metrics["Correctness_Latency"] = round(time.time() - start, 3)
+
+    start = time.time()
+    metrics["BusFactor"] = handle_missing_metrics(calculate_bus_factor, package_data)
+    metrics["BusFactor_Latency"] = round(time.time() - start, 3)
+
+    start = time.time()
+    metrics["ResponsiveMaintainer"] = handle_missing_metrics(calculate_responsive_maintainer, package_lock)
+    metrics["ResponsiveMaintainer_Latency"] = round(time.time() - start, 3)
+
+    start = time.time()
+    metrics["License"] = handle_missing_metrics(calculate_license, package_data)
+    metrics["License_Latency"] = round(time.time() - start, 3)
+
+    # Example NetScore calculation
+    metrics["NetScore"] = sum([metrics["RampUp"], metrics["Correctness"], metrics["BusFactor"],
+                               metrics["ResponsiveMaintainer"], metrics["License"]]) / 5
+    metrics["NetScore_Latency"] = round(time.time() - start, 3)
+
+    return metrics
+
+# Read Input Files
+def read_files(package_path, package_lock_path):
+    with open(package_path, "r") as pkg_file, open(package_lock_path, "r") as lock_file:
+        package_data = json.load(pkg_file)
+        package_lock = json.load(lock_file)
+    return package_data, package_lock
+
+# Main Function
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: ./run.py <path_to_package.json> <path_to_package-lock.json>")
+        sys.exit(1)
+
+    package_data, package_lock = read_files(sys.argv[1], sys.argv[2])
+    result = calculate_metrics(package_data, package_lock)
+    print(json.dumps(result, indent=2))

--- a/MetricsCalculator/sample_package-lock.json
+++ b/MetricsCalculator/sample_package-lock.json
@@ -1,0 +1,21 @@
+{
+    "name": "461-acme-service",
+    "version": "1.0.0",
+    "lockfileVersion": 2,
+    "packages": {
+      "": {
+        "name": "461-acme-service",
+        "version": "1.0.0",
+        "license": "MIT"
+      },
+      "node_modules/acorn": {
+        "version": "8.12.1",
+        "license": "MIT"
+      },
+      "node_modules/axios": {
+        "version": "1.7.7",
+        "license": "MIT"
+      }
+    }
+  }
+  

--- a/MetricsCalculator/sample_package.json
+++ b/MetricsCalculator/sample_package.json
@@ -1,0 +1,21 @@
+{
+    "name": "461-acme-service",
+    "version": "1.0.0",
+    "description": "Sample project",
+    "main": "index.js",
+    "scripts": {
+      "test": "jest",
+      "build": "npx tsc"
+    },
+    "keywords": [],
+    "author": "John Doe",
+    "license": "MIT",
+    "devDependencies": {
+      "@types/jest": "^29.5.13",
+      "@types/node": "^22.5.2",
+      "acorn": "^8.12.1",
+      "axios": "^1.7.7",
+      "typescript": "^5.5.4"
+    }
+  }
+  

--- a/run.py
+++ b/run.py
@@ -1,0 +1,84 @@
+import json
+import sys
+import time
+
+# Metric Calculation Functions
+def calculate_ramp_up(package_data):
+    if "readme" in package_data or "description" in package_data or "main" in package_data:
+        return 0.7  # Example: well-documented
+    return 0.3  # Poorly documented
+
+def calculate_correctness(package_lock):
+    outdated = 0
+    total = len(package_lock.get("packages", {}))
+    for pkg in package_lock.get("packages", {}).values():
+        if pkg.get("dev"):  # Example check: consider dev dependencies
+            outdated += 1
+    return 1 - (outdated / total if total else 0)
+
+def calculate_bus_factor(package_data):
+    return 0.5 if "author" in package_data else 0.2
+
+def calculate_responsive_maintainer(package_lock):
+    recent_updates = [pkg for pkg in package_lock.get("packages", {}).values() if "time" in pkg]
+    return 0.8 if recent_updates else 0.2
+
+def calculate_license(package_data):
+    license_type = package_data.get("license", "").lower()
+    if license_type in ["mit", "apache-2.0", "lgpl-2.1-only"]:
+        return 1.0
+    return 0.0
+
+# Handle Missing Metrics
+def handle_missing_metrics(metric_function, *args):
+    try:
+        return metric_function(*args)
+    except Exception:
+        return -1
+
+# Calculate Metrics and Latencies
+def calculate_metrics(package_data, package_lock):
+    metrics = {}
+    start = time.time()
+    metrics["RampUp"] = handle_missing_metrics(calculate_ramp_up, package_data)
+    metrics["RampUp_Latency"] = round(time.time() - start, 3)
+
+    start = time.time()
+    metrics["Correctness"] = handle_missing_metrics(calculate_correctness, package_lock)
+    metrics["Correctness_Latency"] = round(time.time() - start, 3)
+
+    start = time.time()
+    metrics["BusFactor"] = handle_missing_metrics(calculate_bus_factor, package_data)
+    metrics["BusFactor_Latency"] = round(time.time() - start, 3)
+
+    start = time.time()
+    metrics["ResponsiveMaintainer"] = handle_missing_metrics(calculate_responsive_maintainer, package_lock)
+    metrics["ResponsiveMaintainer_Latency"] = round(time.time() - start, 3)
+
+    start = time.time()
+    metrics["License"] = handle_missing_metrics(calculate_license, package_data)
+    metrics["License_Latency"] = round(time.time() - start, 3)
+
+    # Example NetScore calculation
+    metrics["NetScore"] = sum([metrics["RampUp"], metrics["Correctness"], metrics["BusFactor"],
+                               metrics["ResponsiveMaintainer"], metrics["License"]]) / 5
+    metrics["NetScore_Latency"] = round(time.time() - start, 3)
+
+    return metrics
+
+# Read Input Files
+def read_files(package_path, package_lock_path):
+    with open(package_path, "r") as pkg_file, open(package_lock_path, "r") as lock_file:
+        package_data = json.load(pkg_file)
+        package_lock = json.load(lock_file)
+    return package_data, package_lock
+
+# Main Function
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: ./run.py <path_to_package.json> <path_to_package-lock.json>")
+        sys.exit(1)
+
+    package_data, package_lock = read_files(sys.argv[1], sys.argv[2])
+    result = calculate_metrics(package_data, package_lock)
+    print(json.dumps(result, indent=2))

--- a/sample_package-lock.json
+++ b/sample_package-lock.json
@@ -1,0 +1,21 @@
+{
+    "name": "461-acme-service",
+    "version": "1.0.0",
+    "lockfileVersion": 2,
+    "packages": {
+      "": {
+        "name": "461-acme-service",
+        "version": "1.0.0",
+        "license": "MIT"
+      },
+      "node_modules/acorn": {
+        "version": "8.12.1",
+        "license": "MIT"
+      },
+      "node_modules/axios": {
+        "version": "1.7.7",
+        "license": "MIT"
+      }
+    }
+  }
+  

--- a/sample_package.json
+++ b/sample_package.json
@@ -1,0 +1,21 @@
+{
+    "name": "461-acme-service",
+    "version": "1.0.0",
+    "description": "Sample project",
+    "main": "index.js",
+    "scripts": {
+      "test": "jest",
+      "build": "npx tsc"
+    },
+    "keywords": [],
+    "author": "John Doe",
+    "license": "MIT",
+    "devDependencies": {
+      "@types/jest": "^29.5.13",
+      "@types/node": "^22.5.2",
+      "acorn": "^8.12.1",
+      "axios": "^1.7.7",
+      "typescript": "^5.5.4"
+    }
+  }
+  


### PR DESCRIPTION
The /recommend endpoint generates a list of up to 5 recommended npm packages based on a user-provided description of their requirements. It uses an LLM (like OpenAI) to interpret the description and suggest relevant packages.